### PR TITLE
fix: Sửa nội dung translation cho header.trang_chu

### DIFF
--- a/lib/language-context.tsx
+++ b/lib/language-context.tsx
@@ -13,7 +13,7 @@ interface LanguageContextType {
 
 const translations = {
   vi: {
-    "header.trang_chu": "TRANG CHỦ xx",
+    "header.trang_chu": "TRANG CHỦ",
     "header.booking": "ĐẶT PHÒNG",
     "header.instructions": "CÁCH CHƠI",
     "header.pricing": "BẢNG GIÁ",


### PR DESCRIPTION
## 🤖 Tự động sửa lỗi

**Commit gốc:** `1fe1429`
**Issue liên quan:** #1

### Các thay đổi

**Vấn đề:** Translation key `header.trang_chu` có nội dung "TRANG CHỦ xx" - không phải nội dung UI hợp lệ.

**Giải pháp:** Đổi thành "TRANG CHỦ" (bỏ suffix "xx" không rõ nghĩa).

**File thay đổi:**
- `lib/language-context.tsx`: Sửa giá trị translation từ "TRANG CHỦ xx" → "TRANG CHỦ"

**Tác động:**
- ✅ Người dùng sẽ thấy nội dung UI rõ ràng và chuyên nghiệp
- ✅ Không ảnh hưởng đến logic hay các translation khác
- ✅ Breaking change: Không

⚠️ Cần human review trước khi merge.

---
*🤖 Claude AI*