### PR TITLE
fix: Cải thiện cấu hình test và bổ sung test cases cho 5a99a7e

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -21,4 +21,22 @@ describe('cn utility', () => {
   it('handles undefined and null values', () => {
     expect(cn('foo', undefined, null, 'bar')).toBe('foo bar')
   })
+
+  it('handles array of classes', () => {
+    expect(cn(['foo', 'bar'])).toBe('foo bar')
+    expect(cn(['foo', false, 'bar'])).toBe('foo bar')
+  })
+
+  it('handles object syntax for conditional classes', () => {
+    expect(cn({ 'foo': true, 'bar': false })).toBe('foo')
+    expect(cn({ 'foo': true, 'bar': true })).toBe('foo bar')
+  })
+
+  it('handles complex merging with multiple conflicting classes', () => {
+    expect(cn('px-2 py-1 text-sm', 'px-4 py-2', 'text-lg')).toBe('px-4 py-2 text-lg')
+  })
+
+  it('handles mixed input types', () => {
+    expect(cn('foo', ['bar', 'baz'], { 'qux': true, 'quux': false })).toBe('foo bar baz qux')
+  })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     },
   },
   test: {
-    testTimeout: process.env.CI ? 180000 : 5000,
+    testTimeout: process.env.CI ? 30000 : 5000,
     environment: 'jsdom',
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## 🤖 Tự động sửa lỗi

**Commit gốc:** `5a99a7e`
**Issue liên quan:** #21

### Các thay đổi

#### 1. Giảm testTimeout trong CI (vitest.config.ts)
- **Trước:** `testTimeout: process.env.CI ? 180000 : 5000` (3 phút)
- **Sau:** `testTimeout: process.env.CI ? 30000 : 5000` (30 giây)
- **Lý do:** Timeout 3 phút quá dài cho unit test, có thể che giấu các test chạy chậm hoặc bị treo

#### 2. Bổ sung test cases cho cn utility (__tests__/utils.test.ts)
Thêm 4 test cases mới để cover các edge cases:
- ✅ `handles array of classes` - Test với input là array
- ✅ `handles object syntax for conditional classes` - Test với object syntax
- ✅ `handles complex merging with multiple conflicting classes` - Test merge nhiều conflicting classes
- ✅ `handles mixed input types` - Test với nhiều loại input khác nhau

### Impact
- ✅ Cải thiện tốc độ CI pipeline (giảm timeout không cần thiết)
- ✅ Tăng test coverage cho cn utility từ 5 lên 9 test cases
- ✅ Đảm bảo cn utility hoạt động đúng với mọi input type

⚠️ **Cần human review trước khi merge.**

---
*🤖 Generated by Claude AI*